### PR TITLE
Integrate Metadata Aware Chunking with DBClient

### DIFF
--- a/ClauseExtractor.py
+++ b/ClauseExtractor.py
@@ -5,14 +5,25 @@ FILENAME = "./data/38214-hc0.docx"
 f = open(FILENAME,'rb')
 doc = Document(f)
 
-p = doc.add_paragraph('This is a paragraph ')
-
 def iter_readings(paragraphs):
     for paragraph in paragraphs:
         if paragraph.style.name.startswith('Heading'):
             yield paragraph
 
+def iter_paragraphs(doc):
+    for paragraph in doc.paragraphs:
+        yield paragraph.text
+
+def iter_sections(doc):
+    for part in doc.iter_inner_content():
+        if part.style.name.startswith('Heading'):
+            yield "hd: "+part.text
+        elif "table" in part.style.name.lower():
+            yield "tbl: " + part.style.name
+        else:
+            yield part.text
+
 
 if __name__ == "__main__":
-    for heading in iter_readings(doc.paragraphs):
-        print(heading.text)
+    for heading in iter_sections(doc):
+        print(heading)

--- a/ClauseExtractor.py
+++ b/ClauseExtractor.py
@@ -1,6 +1,6 @@
 from docx import Document
 
-FILENAME = "./data/38214-hc0.docx"
+FILENAME = "./data/TestFile.docx"
 
 f = open(FILENAME,'rb')
 doc = Document(f)
@@ -14,12 +14,21 @@ def iter_paragraphs(doc):
     for paragraph in doc.paragraphs:
         yield paragraph.text
 
+def parse_table(table):
+    for row_idx,row in enumerate(table.rows):
+        for col_idx,col in enumerate(row.cells):
+            if col.tables:
+                for nested_table in col.tables:
+                    parse_table(nested_table)
+            else:
+                yield col.text
+
 def iter_sections(doc):
     for part in doc.iter_inner_content():
         if part.style.name.startswith('Heading'):
             yield "hd: "+part.text
         elif "table" in part.style.name.lower():
-            yield "tbl: " + part.style.name
+            yield "tbl: " + f"{[val for val in parse_table(part)]}"
         else:
             yield part.text
 

--- a/ClauseExtractor.py
+++ b/ClauseExtractor.py
@@ -1,0 +1,18 @@
+from docx import Document
+
+FILENAME = "./data/38214-hc0.docx"
+
+f = open(FILENAME,'rb')
+doc = Document(f)
+
+p = doc.add_paragraph('This is a paragraph ')
+
+def iter_readings(paragraphs):
+    for paragraph in paragraphs:
+        if paragraph.style.name.startswith('Heading'):
+            yield paragraph
+
+
+if __name__ == "__main__":
+    for heading in iter_readings(doc.paragraphs):
+        print(heading.text)

--- a/DBClient.py
+++ b/DBClient.py
@@ -2,44 +2,18 @@ from langchain_community.vectorstores import Chroma
 from langchain_text_splitters import RecursiveCharacterTextSplitter
 from langchain_community.document_loaders import Docx2txtLoader
 from langchain_core.documents import Document
+from MetadataAwareChunker import getSectionedChunks
 import chromadb
 from settings import config
 import pickle
 import os 
 class DBClient:
     @staticmethod #remove this decorator after preliminary testing
-    def addMetadataToDoc(doc:list[Document])->list[Document]:
-        #we need to add metadata that represents the clause something is from
-        new_doc = []
-        for d in doc:
-            d.metadata = {**d.metadata,'section':'Clause ABCD'}
-            new_doc.append(d)
-        new_doc = doc
-        print(new_doc)
-        return new_doc
-
-    @staticmethod #remove this decorator after preliminary testing
     def addDocsFromFilePath(file_list):
-        """@file_list: list(str) of file names. Not absolute paths"""
+        """@file_list: list(str) of file names. Not absolute/relative paths"""
         docs = []
-        text_splitter = RecursiveCharacterTextSplitter(chunk_size=1000, chunk_overlap=200, add_start_index=True) #creates a text splitter, which breaks apart the document into text
-        for file in file_list:
-            loader = Docx2txtLoader(os.path.join(config['DOC_DIR'],file))
-
-            if not config['IS_PICKLE']:
-                raw_doc = loader.load_and_split() 
-            # Adam Chen Pickle Mode
-            else:
-                with open(os.path.join(config['DOC_DIR'],file), 'rb') as handle:
-                    raw_doc = pickle.load(handle)    
-            # End Pickle mode
-            print("metadata: ")
-            print(raw_doc[0].metadata)
-
-            doc = text_splitter.split_documents(raw_doc) #applies the text splitter to the documents
-            #for each doc, add new metadata on section.
-            doc = DBClient.addMetadataToDoc(doc)
-            docs.extend(doc)
+        file_list = [os.path.join(config['DOC_DIR'],file) for file in file_list]
+        docs = getSectionedChunks(file_list)
         return docs
 
     def constructBaseDB(self,embedding_model):
@@ -76,4 +50,4 @@ class DBClient:
     
 if __name__ == "__main__":
     file_list = ["38214-hc0.docx"]
-    DBClient.addDocsFromFilePath(file_list)
+    print(DBClient.addDocsFromFilePath(file_list))

--- a/DBClient.py
+++ b/DBClient.py
@@ -8,8 +8,7 @@ from settings import config
 import pickle
 import os 
 class DBClient:
-    @staticmethod #remove this decorator after preliminary testing
-    def addDocsFromFilePath(file_list):
+    def addDocsFromFilePath(self,file_list):
         """@file_list: list(str) of file names. Not absolute/relative paths"""
         docs = []
         file_list = [os.path.join(config['DOC_DIR'],file) for file in file_list]

--- a/DBClient.py
+++ b/DBClient.py
@@ -1,13 +1,25 @@
 from langchain_community.vectorstores import Chroma
 from langchain_text_splitters import RecursiveCharacterTextSplitter
 from langchain_community.document_loaders import Docx2txtLoader
+from langchain_core.documents import Document
 import chromadb
 from settings import config
 import pickle
 import os 
-
 class DBClient:
-    def addDocsFromFilePath(self,file_list):
+    @staticmethod #remove this decorator after preliminary testing
+    def addMetadataToDoc(doc:list[Document])->list[Document]:
+        #we need to add metadata that represents the clause something is from
+        new_doc = []
+        for d in doc:
+            d.metadata = {**d.metadata,'section':'Clause ABCD'}
+            new_doc.append(d)
+        new_doc = doc
+        print(new_doc)
+        return new_doc
+
+    @staticmethod #remove this decorator after preliminary testing
+    def addDocsFromFilePath(file_list):
         """@file_list: list(str) of file names. Not absolute paths"""
         docs = []
         text_splitter = RecursiveCharacterTextSplitter(chunk_size=1000, chunk_overlap=200, add_start_index=True) #creates a text splitter, which breaks apart the document into text
@@ -25,6 +37,8 @@ class DBClient:
             print(raw_doc[0].metadata)
 
             doc = text_splitter.split_documents(raw_doc) #applies the text splitter to the documents
+            #for each doc, add new metadata on section.
+            doc = DBClient.addMetadataToDoc(doc)
             docs.extend(doc)
         return docs
 
@@ -60,3 +74,6 @@ class DBClient:
             return self.vector_db.as_retriever()
         return self.vector_db.as_retriever(search_kwargs=search_kwargs)
     
+if __name__ == "__main__":
+    file_list = ["38214-hc0.docx"]
+    DBClient.addDocsFromFilePath(file_list)

--- a/MetadataAwareChunker.py
+++ b/MetadataAwareChunker.py
@@ -15,7 +15,7 @@ def getSectionedChunks(file_list):
 
         text_splitter = RecursiveCharacterTextSplitter(chunk_size=1000,chunk_overlap=200)
 
-        current_section = None
+        current_section = "N/A"
         sections = []
 
         for paragraph in doc.paragraphs:

--- a/MetadataAwareChunker.py
+++ b/MetadataAwareChunker.py
@@ -13,11 +13,14 @@ def getSectionedChunks(file_list):
         f = open(file,'rb')
         doc = DocParser(f)
 
-        text_splitter = RecursiveCharacterTextSplitter(chunk_size=1000,chunk_overlap=200)
+        text_splitter = RecursiveCharacterTextSplitter(chunk_size=1000,chunk_overlap=200,add_start_index=True)
 
         current_section = "N/A"
         sections = []
-
+        #TODO: Switch to collecting a "current section" list of text chunks
+        # currently there's no overlap between paragraphs in the same section which is bad for retrieval
+        # We want to collect (section_text,current_section) where section_text is a combination of paragraphs
+        # Then, we use the text_splitter to split it into split chunks
         for paragraph in doc.paragraphs:
             text = paragraph.text.strip()
             if paragraph.style.name.startswith('Heading'):

--- a/MetadataAwareChunker.py
+++ b/MetadataAwareChunker.py
@@ -3,6 +3,18 @@ from langchain_text_splitters import RecursiveCharacterTextSplitter
 from langchain_core.documents import Document
 
 
+def parse_table(table):
+    """@input: docx table. Consists of rows and cells and the cells may have other tables.
+    This is a helper function to help parse tables from docx. 
+    It is needed as tables may contain nested tables."""
+    for row_idx,row in enumerate(table.rows):
+        for col_idx,col in enumerate(row.cells):
+            if col.tables:
+                for nested_table in col.tables:
+                    parse_table(nested_table)
+            else:
+                yield col.text
+
 def getSectionedChunks(file_list):
     """@input: file_list. List of files in relative path that will be chunked.
     Returns: master list chunks_with_metadata that has chunks of all the files stored as langchain Documents.
@@ -15,25 +27,36 @@ def getSectionedChunks(file_list):
 
         text_splitter = RecursiveCharacterTextSplitter(chunk_size=1000,chunk_overlap=200,add_start_index=True)
 
-        current_section = "N/A"
+        current_section_title = "N/A"
+        current_section_text = ""
         sections = []
         #TODO: Switch to collecting a "current section" list of text chunks
         # currently there's no overlap between paragraphs in the same section which is bad for retrieval
         # We want to collect (section_text,current_section) where section_text is a combination of paragraphs
         # Then, we use the text_splitter to split it into split chunks
-        for paragraph in doc.paragraphs:
-            text = paragraph.text.strip()
-            if paragraph.style.name.startswith('Heading'):
-                current_section = paragraph.text
-            elif text:
-                sections.append((text,current_section))
-            
-        for text,section in sections:
+        for part in doc.iter_inner_content():
+            if part.style.name.startswith('Heading'):
+                # update current section
+                sections.append((current_section_text,current_section_title))
+                current_section_text = ""
+                current_section_title = part.text
+            elif "table" in part.style.name.lower():
+                print(f"*******HERE IS TABLE*********\n")
+                for table_datum in parse_table(part):
+                    current_section_text += table_datum
+            else:
+                # append text to current section
+                current_section_text += part.text
+        
+        #Add last section to sections
+        sections.append((current_section_text,current_section_title))
+
+        for text,section_name in sections:
             split_chunks = text_splitter.split_text(text)
             for chunk in split_chunks:
                 chunks_with_metadata.append(Document(
                     page_content=chunk,
-                    metadata={'source':file,'section':section}
+                    metadata={'source':file,'section':section_name}
                 ))
     return chunks_with_metadata
 
@@ -57,5 +80,5 @@ def getFullFileChunks(file_list):
     return chunks
 
 if __name__ =="__main__":
-    file_list = ["./data/38214-hc0.docx"]
-    print(getSectionedChunks(file_list)[-100])
+    file_list = ["./data/TestFile.docx"]
+    print(getSectionedChunks(file_list))

--- a/MetadataAwareChunker.py
+++ b/MetadataAwareChunker.py
@@ -21,7 +21,7 @@ def getSectionedChunks(file_list):
         # currently there's no overlap between paragraphs in the same section which is bad for retrieval
         # We want to collect (section_text,current_section) where section_text is a combination of paragraphs
         # Then, we use the text_splitter to split it into split chunks
-        """for paragraph in doc.paragraphs:
+        for paragraph in doc.paragraphs:
             text = paragraph.text.strip()
             if paragraph.style.name.startswith('Heading'):
                 current_section = paragraph.text
@@ -34,17 +34,27 @@ def getSectionedChunks(file_list):
                 chunks_with_metadata.append(Document(
                     page_content=chunk,
                     metadata={'source':file,'section':section}
-                ))"""
+                ))
+    return chunks_with_metadata
+
+def getFullFileChunks(file_list):
+    chunks = []
+    for file in file_list:
+
+        f = open(file,'rb')
+        doc = DocParser(f)
+
+        text_splitter = RecursiveCharacterTextSplitter(chunk_size=1000,chunk_overlap=200,add_start_index=True)
         text = ""
         for paragraph in doc.paragraphs:
             text += paragraph.text
         split_chunks = text_splitter.split_text(text)
         for chunk in split_chunks:
-            chunks_with_metadata.append(Document(
+            chunks.append(Document(
                 page_content=chunk,
                 metadata={'source':file}
             ))
-    return chunks_with_metadata
+    return chunks
 
 if __name__ =="__main__":
     file_list = ["./data/38214-hc0.docx"]

--- a/MetadataAwareChunker.py
+++ b/MetadataAwareChunker.py
@@ -4,6 +4,9 @@ from langchain_core.documents import Document
 
 
 def getSectionedChunks(file_list):
+    """@input: file_list. List of files in relative path that will be chunked.
+    Returns: master list chunks_with_metadata that has chunks of all the files stored as langchain Documents.
+    These Documents have section metadata"""
     chunks_with_metadata= []
     for file in file_list:
 

--- a/MetadataAwareChunker.py
+++ b/MetadataAwareChunker.py
@@ -21,7 +21,7 @@ def getSectionedChunks(file_list):
         # currently there's no overlap between paragraphs in the same section which is bad for retrieval
         # We want to collect (section_text,current_section) where section_text is a combination of paragraphs
         # Then, we use the text_splitter to split it into split chunks
-        for paragraph in doc.paragraphs:
+        """for paragraph in doc.paragraphs:
             text = paragraph.text.strip()
             if paragraph.style.name.startswith('Heading'):
                 current_section = paragraph.text
@@ -34,7 +34,16 @@ def getSectionedChunks(file_list):
                 chunks_with_metadata.append(Document(
                     page_content=chunk,
                     metadata={'source':file,'section':section}
-                ))
+                ))"""
+        text = ""
+        for paragraph in doc.paragraphs:
+            text += paragraph.text
+        split_chunks = text_splitter.split_text(text)
+        for chunk in split_chunks:
+            chunks_with_metadata.append(Document(
+                page_content=chunk,
+                metadata={'source':file}
+            ))
     return chunks_with_metadata
 
 if __name__ =="__main__":

--- a/README.md
+++ b/README.md
@@ -26,3 +26,7 @@ docx2txt
 Get System working again
 Refactor & clean up
 Build automatic fetching of docs
+
+# Things of note:
+Initializing the db only happens when the resync button is hit. 
+The DB is peristent so between runs it

--- a/ReferenceExtractor.py
+++ b/ReferenceExtractor.py
@@ -1,5 +1,6 @@
 import re
 from utils import RefObj
+from langchain_core.documents import Document
 
 class ReferenceExtractor:
     def __init__(self):
@@ -38,6 +39,20 @@ class ReferenceExtractor:
             refWithoutSrc = matchedStr.replace(f" of {src}","")
             references.append(RefObj(reference=refWithoutSrc,src=src))
         return references
+
+    def runREWithDocList(self,docs:list[Document])->list[RefObj]:
+        """@docs: list of Documents, where Document is from langchain.
+        Document: {metadata:{},page_content:,start_index:}
+        Returns: a list of RefObj where each RefObj represents a reference found in the list of docs.
+        RefObj: {reference:,src:}
+        Note that as of right now, there may be duplicate RefObjs"""
+        allRefs = []
+        for doc in docs:
+            matchedStrings = self.findAllMatches(doc.page_content)
+            references = self.extractDocumentFromStrings(matchedStrings)
+            allRefs.extend(references)
+        return allRefs
+
 
 if __name__ == "__main__":
     examples = ["The determination of the used resource allocation table is defined in clause 6.1.2.1.1 of [4, TS 38.211] though you can also check Clause 6.2 or clause 6.3.",

--- a/ReferenceExtractor.py
+++ b/ReferenceExtractor.py
@@ -57,7 +57,7 @@ class ReferenceExtractor:
 if __name__ == "__main__":
     examples = ["The determination of the used resource allocation table is defined in clause 6.1.2.1.1 of [4, TS 38.211] though you can also check Clause 6.2 or clause 6.3.",
     "Aperiodic CSI-RS is configured and triggered/activated as described in Clause 8.5.1.2", 
-    "The UE shall derive CQI as specified in clause 5.2.2.1", "the UE procedure for receiving the PDSCH upon detection of a PDCCH follows clause 5.1 and the QCL assumption for the PDSCH as defined in clause 5.1.5"]
+    "The UE shall derive CQI as specified in clause 5.2.2.1 of [TS, ]", "the UE procedure for receiving the PDSCH upon detection of a PDCCH follows clause 5.1 and the QCL assumption for the PDSCH as defined in clause 5.1.5"]
     re = ReferenceExtractor()
     matchedStrings = re.findAllMatches(examples[2])
     print(re.extractDocumentFromStrings(matchedStrings))

--- a/TestFile.py
+++ b/TestFile.py
@@ -1,0 +1,34 @@
+from docx import Document as DocParser
+from langchain_text_splitters import RecursiveCharacterTextSplitter
+from langchain_core.documents import Document
+
+FILENAME = "./data/38214-hc0.docx"
+
+f = open(FILENAME,'rb')
+doc = DocParser(f)
+
+def getSectionedChunks(doc):
+    text_splitter = RecursiveCharacterTextSplitter(chunk_size=1000,chunk_overlap=200)
+
+    current_section = None
+    sections = []
+    chunks_with_metadata= []
+
+    for paragraph in doc.paragraphs:
+        text = paragraph.text.strip()
+        if paragraph.style.name.startswith('Heading'):
+            current_section = paragraph.text
+        elif text:
+            sections.append((text,current_section))
+        
+    for text,section in sections:
+        split_chunks = text_splitter.split_text(text)
+        for chunk in split_chunks:
+            chunks_with_metadata.append({
+                "page_content":chunk,
+                "metadata":{'section':section}
+            })
+    return chunks_with_metadata
+
+if __name__ =="__main__":
+    print(getSectionedChunks(doc))

--- a/TestFile.py
+++ b/TestFile.py
@@ -2,33 +2,35 @@ from docx import Document as DocParser
 from langchain_text_splitters import RecursiveCharacterTextSplitter
 from langchain_core.documents import Document
 
-FILENAME = "./data/38214-hc0.docx"
 
-f = open(FILENAME,'rb')
-doc = DocParser(f)
-
-def getSectionedChunks(doc):
-    text_splitter = RecursiveCharacterTextSplitter(chunk_size=1000,chunk_overlap=200)
-
-    current_section = None
-    sections = []
+def getSectionedChunks(file_list):
     chunks_with_metadata= []
+    for file in file_list:
 
-    for paragraph in doc.paragraphs:
-        text = paragraph.text.strip()
-        if paragraph.style.name.startswith('Heading'):
-            current_section = paragraph.text
-        elif text:
-            sections.append((text,current_section))
-        
-    for text,section in sections:
-        split_chunks = text_splitter.split_text(text)
-        for chunk in split_chunks:
-            chunks_with_metadata.append({
-                "page_content":chunk,
-                "metadata":{'section':section}
-            })
+        f = open(file,'rb')
+        doc = DocParser(f)
+
+        text_splitter = RecursiveCharacterTextSplitter(chunk_size=1000,chunk_overlap=200)
+
+        current_section = None
+        sections = []
+
+        for paragraph in doc.paragraphs:
+            text = paragraph.text.strip()
+            if paragraph.style.name.startswith('Heading'):
+                current_section = paragraph.text
+            elif text:
+                sections.append((text,current_section))
+            
+        for text,section in sections:
+            split_chunks = text_splitter.split_text(text)
+            for chunk in split_chunks:
+                chunks_with_metadata.append(Document(
+                    page_content=chunk,
+                    metadata={'source':file,'section':section}
+                ))
     return chunks_with_metadata
 
 if __name__ =="__main__":
-    print(getSectionedChunks(doc))
+    file_list = ["./data/38214-hc0.docx"]
+    print(getSectionedChunks(file_list)[-100])

--- a/controller.py
+++ b/controller.py
@@ -49,7 +49,7 @@ Question: {input}""")
 
         #update chroma
         self.db.updateDB(file_list)
-
+        print(f"done resyncing")
         #reconstruct retriever
 
     def toggleDatabase(self):
@@ -96,7 +96,7 @@ Question: {input}""")
 
         all_docs = resp['context'][:]
         ext_src: list[RefObj] = RExt.runREWithDocList(docs=all_docs)
-        print(f"ext_src is {ext_src[0].reference}")
+        #print(f"ext_src is {ext_src[0].reference}")
         for refObj in ext_src:
             res = self.retriever.invoke(f"You are an expert retriever with access to a vector database. Parse through the database, and only return data from this section: {refObj.reference}")
             print(f"for ref {refObj.reference}, res is {res}")

--- a/controller.py
+++ b/controller.py
@@ -85,6 +85,12 @@ Question: {input}""")
                             retriever=self.db.getRetriever(search_kwargs={'filter': name_filter}), llm=self.llm
                         )            
 
+    def getResponseWithRetrieval(self,prompt,history):
+        doc_chain = create_stuff_documents_chain(self.llm, self.prompt)
+        retrieval_chain = create_retrieval_chain(self.retriever, doc_chain)
+    
+        resp = retrieval_chain.invoke({"input":prompt,"history": history})
+        return resp
 
     def runController(self, prompt, history, selected_docs):
 
@@ -97,10 +103,8 @@ Question: {input}""")
             # retrieval chain passed the load of deciding what document to use to answer to the retriever.
             history = self.convert_history(history)
             if self.isDatabaseTriggered:
-                doc_chain = create_stuff_documents_chain(self.llm, self.prompt)
-                retrieval_chain = create_retrieval_chain(self.retriever, doc_chain)
-    
-                resp = retrieval_chain.invoke({"input":prompt,"history": history})
+                resp = self.getResponseWithRetrieval(prompt,history)
+                print(f"resp is {resp}")
                 response = resp['answer']
             else:
                 chain = self.prompt | self.llm

--- a/controller.py
+++ b/controller.py
@@ -94,12 +94,12 @@ Question: {input}""")
     
         resp = retrieval_chain.invoke({"input":prompt,"history": history})
 
-        all_docs = resp['context'][:]
+        """all_docs = resp['context'][:]
         ext_src: list[RefObj] = RExt.runREWithDocList(docs=all_docs)
         #print(f"ext_src is {ext_src[0].reference}")
         for refObj in ext_src:
             res = self.retriever.invoke(f"You are an expert retriever with access to a vector database. Parse through the database, and only return data from this section: {refObj.reference}")
-            print(f"for ref {refObj.reference}, res is {res}")
+            print(f"for ref {refObj.reference}, res is {res}")"""
 
         return resp
 

--- a/utils.py
+++ b/utils.py
@@ -9,6 +9,9 @@ def unzipFile(filepath,dest_dir):
     
     os.remove(filepath)
 
+def format_docs(docs):
+    return "\n\n".join(doc.page_content for doc in docs)
+
 class RefObj:
     def __init__(self,reference:str,src:str):
         self.reference = reference


### PR DESCRIPTION
The branch name is a misnomer.
We want to work towards filtering by "section" when retrieving extra context with the retriever. To do so, we must embed metadata info on the section a chunk's text belongs to with the chunks that are vectorized and stored in the vector db. However, there is no inbuilt way to assign section information as it is a concept we have come up with. So we built our own.

Here we:

- Build a custom loader and chunker which takes in each file, breaks it apart into chunks with overlap, and appends "section" metadata to each chunk
-determine "section" by identifying section headings based on styling.
- Ensure parity with the old Doc2txtloader so there is no loss of functionality with our approach