### PR TITLE
Add Frontend Display of Retrieved Chunks and Code Cleanup

### DIFF
--- a/DBClient.py
+++ b/DBClient.py
@@ -5,7 +5,6 @@ from langchain_core.documents import Document
 from MetadataAwareChunker import getSectionedChunks
 import chromadb
 from settings import config
-import pickle
 import os 
 class DBClient:
     def addDocsFromFilePath(self,file_list):

--- a/MultiStageRetriever.py
+++ b/MultiStageRetriever.py
@@ -82,6 +82,6 @@ class MultiStageRetriever:
 
         resp_answer = self.doc_chain.invoke({"context":retrieved_docs,"input":query,"history":history})
         resp = {"input":query,"history":history,"context":retrieved_docs,"answer":resp_answer}
-        return resp
+        return resp,org_docs,additional_docs
     
     

--- a/README.md
+++ b/README.md
@@ -8,9 +8,8 @@ It should have these vars:
 1. `API_KEY`
 2. `DOC_DIR`
 3. `MODEL_NAME`
-4. `IS_PICKLE` -> represents whether pickle mode is on. Pickling basically caches the documents as large byte fles so as to save on compute.
-5. `NUM_EXTRA_DOCS` -> the number of additional docs to retrieve per run. NOT depth, closer to top k
-6. `CHROMA_DIR` -> The directory the chromadb sqlite db will be stored
+4. `NUM_EXTRA_DOCS` -> the number of additional docs to retrieve per run. NOT depth, closer to top k
+5. `CHROMA_DIR` -> The directory the chromadb sqlite db will be stored
 
 
 # Running the system

--- a/controller.py
+++ b/controller.py
@@ -101,8 +101,8 @@ Question: {input}""")
     
 
     def getResponseWithRetrieval(self,prompt,history):
-        resp = self.retriever.invoke(query=prompt,history=history,db=self.contextDB)
-        return resp
+        resp,orig_docs,additional_docs = self.retriever.invoke(query=prompt,history=history,db=self.contextDB)
+        return resp,orig_docs,additional_docs
 
     def runController(self, prompt, history, selected_docs):
 
@@ -115,14 +115,15 @@ Question: {input}""")
             # retrieval chain passed the load of deciding what document to use to answer to the retriever.
             history = self.convert_history(history)
             if self.isDatabaseTriggered:
-                resp = self.getResponseWithRetrieval(prompt,history)
+                resp,orig_docs,additional_docs = self.getResponseWithRetrieval(prompt,history)
                 print(f"resp is {resp}")
                 response = resp['answer']
             else:
                 chain = self.prompt | self.llm
                 resp = chain.invoke({"input":prompt,"history": history})
                 response = resp.content
-            return response
+                orig_docs,additional_docs = [],[]
+            return response,orig_docs,additional_docs
     
 if __name__ == "__main__":
     c = Controller()

--- a/controller.py
+++ b/controller.py
@@ -13,7 +13,6 @@ import os
 API_KEY = config["API_KEY"]
 M_NAME = config["MODEL_NAME"]
 DOC_DIR = config["DOC_DIR"]
-IS_PICKLE = config["IS_PICKLE"]
 
 class Controller:
     def __init__(self):

--- a/controller.py
+++ b/controller.py
@@ -86,9 +86,9 @@ Question: {input}""")
 {context}
 </context>
 Question: {input}""")
+            self.retriever.reconstructDocChain(self.prompt)
         else:
             self.prompt = ChatPromptTemplate.from_template("""Answer the following question as best you can Question: {input}""")
-        self.retriever.reconstructDocChain(self.prompt)
         return self.isDatabaseTriggered
 
     def convert_history(self, history):

--- a/frontend.py
+++ b/frontend.py
@@ -38,8 +38,6 @@ DOC_DIR = config["DOC_DIR"]
 def getFileList():
     file_lst = []
     for file in os.listdir(DOC_DIR):
-        if file[-7:] == ".pickle":
-            file = file[:-7]
         file_lst.append(file)
     return gr.Dropdown(choices=file_lst,multiselect=True)
 

--- a/frontend.py
+++ b/frontend.py
@@ -10,9 +10,9 @@ def respond(prompt,history,selected_docs):
     """@prompt: question to the model
     @history: the history of the conversation, stored in "turns" of HumanMessage,AIMessage
     @selected_docs: a list of documents that were selected from the dropdown."""
-    resp = langchain_controller.runController(prompt,history,selected_docs)
+    resp,orig_docs,additional_docs = langchain_controller.runController(prompt,history,selected_docs)
     history.append((prompt,resp))
-    return history
+    return history,orig_docs,additional_docs
 
 
 def adjustToggle():
@@ -58,6 +58,9 @@ with gr.Blocks() as demo:
     selected_docs = gr.Dropdown(choices=[], multiselect=True)
     textbox.change(fn=getFileList,outputs=[selected_docs])
 
-    textbox.submit(respond,inputs=[textbox,chatbot,selected_docs],outputs=chatbot)
+    retrieved_orig_docs = gr.Textbox(label="Chunks that were originally retrieved")
+    retrieved_additional_docs = gr.Textbox(label="Chunks that were secondarily retrieved, via deep context")
+
+    textbox.submit(respond,inputs=[textbox,chatbot,selected_docs],outputs=[chatbot,retrieved_orig_docs,retrieved_additional_docs])
 
 demo.launch(share=True)


### PR DESCRIPTION
- Removed pickling
- Fixed issue with switching to non-RAG mode
- Add textboxes on frontend that display retrieved docs/chunks (both first and second order) that sync with response