### PR TITLE
Allow for LLM-Powered Document Wide Metadata Extraction

### DIFF
--- a/DBClient.py
+++ b/DBClient.py
@@ -2,7 +2,7 @@ from langchain_community.vectorstores import Chroma
 from langchain_text_splitters import RecursiveCharacterTextSplitter
 from langchain_community.document_loaders import Docx2txtLoader
 from langchain_core.documents import Document
-from MetadataAwareChunker import getSectionedChunks
+from MetadataAwareChunker import getSectionedChunks,addExtraDocumentWideMetadataForReason
 import chromadb
 from settings import config
 import os 
@@ -11,7 +11,11 @@ class DBClient:
         """@file_list: list(str) of file names. Not absolute/relative paths"""
         docs = []
         file_list = [os.path.join(config['DOC_DIR'],file) for file in file_list]
-        docs = getSectionedChunks(file_list)
+        if self.metadata_func:
+            docs = getSectionedChunks(file_list,addExtraDocumentWideMetadata=self.metadata_func)
+        else:
+            docs = getSectionedChunks(file_list)
+        
         return docs
 
     def constructBaseDB(self,embedding_model,collection_name):
@@ -22,9 +26,13 @@ class DBClient:
 
         return vector_db
     
-    def __init__(self,embedding_model,collection_name="context"):
+    def __init__(self,embedding_model,collection_name=config["SPEC_COLL_NAME"]):
         #construct chroma base db            
         self.vector_db = self.constructBaseDB(embedding_model,collection_name=collection_name)
+        if collection_name == config["TDOC_COLL_NAME"]:
+            self.metadata_func = addExtraDocumentWideMetadataForReason
+        else:
+            self.metadata_func = None
 
     def updateDB(self,new_file_list):
         """@new_file_list: list(str) list of file names (not abs paths)

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ langchain_community
 chromadb
 bs4
 docx2txt
+MarkItDown
 
 # Things of note:
 Initializing the db only happens when the resync button is hit. 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ It should have these vars:
 3. `MODEL_NAME`
 4. `NUM_EXTRA_DOCS` -> the number of additional docs to retrieve per run. NOT depth, closer to top k
 5. `CHROMA_DIR` -> The directory the chromadb sqlite db will be stored
+6. `SPEC_COLL_NAME`: "context" -> These should be set to these values. They represent what the collections in the chromadb database will be named. There are two collections, one to store spec content and the other to store tdoc content.
+7. `TDOC_COLL_NAME`: "reason"
 
 
 # Running the system

--- a/controller.py
+++ b/controller.py
@@ -13,6 +13,8 @@ import os
 API_KEY = config["API_KEY"]
 M_NAME = config["MODEL_NAME"]
 DOC_DIR = config["DOC_DIR"]
+SPEC_COLL_NAME = config["SPEC_COLL_NAME"]
+TDOC_COLL_NAME = config["TDOC_COLL_NAME"]
 
 class Controller:
     def __init__(self):
@@ -26,7 +28,7 @@ Question: {input}""")
         embeddings = OpenAIEmbeddings(model='text-embedding-3-large',api_key=API_KEY) #Since we're using openAI's llm, we have to use its embedding model
         
         self.contextDB = DBClient(embedding_model=embeddings)
-        self.reasonDB = DBClient(embedding_model=embeddings,collection_name="reason")
+        self.reasonDB = DBClient(embedding_model=embeddings,collection_name=TDOC_COLL_NAME)
 
         endpoints = ["https://www.3gpp.org/ftp/Specs/latest/Rel-16/38_series","https://www.3gpp.org/ftp/Specs/latest/Rel-17/38_series"]
         #endpoints += ["https://www.3gpp.org/ftp/Specs/latest/Rel-18/38_series"]


### PR DESCRIPTION
We had an issue before with textboxes not being seen by `python-docx`. However, because we got version and docid metadata by parsing the first page of the document, we needed to find a way around the issue. So, we built a new way to extract metadata which invokes an LLM after passing the first page of the document extracted via md conversion (to be able to read textbox) to get the metadata.
